### PR TITLE
Update De-Identifying DICOMS.md

### DIFF
--- a/BIDS/De-Identifying DICOMS.md
+++ b/BIDS/De-Identifying DICOMS.md
@@ -136,7 +136,7 @@ Here we have a few example participants undergoing DICOM anonymization. Observe 
 
 DICOM Anonymization occurs in two steps, the anonymization step and the quality control step (see [Instructions](##instructions)). To use this documentation,
 
-1. The person conducting the anonymization should put their initials in the "DICOMS Anonymized column" only for the participants their currently working on. 
+1. The person conducting the anonymization should put their initials in the "DICOMS Anonymized column" only for the participants they're currently working on. 
 2. Once anonymization is complete for a participant, the entry background color should be changed to green to indicate that the data is ready for review.
 3. The quality control reviewer should similarly mark their initials in the "DICOM anonymization check" only for participants they are actively reviewing.
 4. Tags with any problems should be noted here next to the reviewers initials with a brief explanation of what the problem is. This allows the people doing the anonymization to review and fix these.


### PR DESCRIPTION
A few queries:


61. "Open DicomBrowser by typing DicomBrowser in the terminal"
Is DicomBrowser automatically added to your path using the install instructions you provided? Or was this an additional step not specified in the docs?

63. "4. In the top menu bar, click on '*File*' >> '*Open*', navigate to the folder you intend to anonymize. You can select the entire participant folder and DicomBrowser with search through all subfolders, loading any DICOM files it finds. This allows you to anonymize data for all of a participant's scans at once."
You can anonymize more than one participant at once. I think the max we tried for SNAP was 10.

98. "9. Click on the value field for **(0008, 0022)** "Acquisition Date". Change this to today's date YYYYMMDD.
   + Note that this date format (year, month, day) is preferred because it is compliant with the ISO 8601 international standard for communication of dates. [[5]](#5)[[6]](#6)."
Clarify that an acquisition date in this format is necessary for most Dicom 2 Nifti conversion software?